### PR TITLE
introduce Rocky Linux

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,6 +18,7 @@ jobs:
           - centos7
           - centos8
           - almalinux8
+          - rockylinux8
         platform:
           - linux/amd64
           # - linux/arm64

--- a/Dockerfile.rockylinux8
+++ b/Dockerfile.rockylinux8
@@ -1,0 +1,10 @@
+FROM rockylinux/rockylinux:8.4-rc1
+ENV HOME /
+RUN dnf update -y
+RUN dnf install -y rpm-build redhat-rpm-config rpmdevtools gcc-c++ tar make tcl which procps openssl-devel
+RUN rpmdev-setuptree
+ADD ./rpmbuild/ /rpmbuild/
+RUN chown -R root:root /rpmbuild
+RUN rpmbuild -ba /rpmbuild/SPECS/redis.spec
+RUN tar -czf /tmp/redis.tar.gz -C /rpmbuild RPMS SRPMS
+CMD ["/bin/true"]

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ IMAGE_NAME := redis-package
 
 .PHONY: all clean amazonlinux2 centos7 centos8 almalinux8 rockylinux8
 
-all: amazonlinux2 centos7 centos8 almalinux8rockylinux8
+all: amazonlinux2 centos7 centos8 almalinux8 rockylinux8
 amazonlinux2: amazonlinux2.build
 centos7: centos7.build
 centos8: centos8.build

--- a/Makefile
+++ b/Makefile
@@ -2,13 +2,14 @@ SOURCE_ARCHIVE := redis-6.2.4.tar.gz
 TARGZ_FILE := redis.tar.gz
 IMAGE_NAME := redis-package
 
-.PHONY: all clean amazonlinux2 centos7 centos8 almalinux8
+.PHONY: all clean amazonlinux2 centos7 centos8 almalinux8 rockylinux8
 
-all: amazonlinux2 centos7 centos8 almalinux8
+all: amazonlinux2 centos7 centos8 almalinux8rockylinux8
 amazonlinux2: amazonlinux2.build
 centos7: centos7.build
 centos8: centos8.build
 almalinux8: almalinux8.build
+rockylinux8: rockylinux8.build
 
 rpmbuild/SOURCES/$(SOURCE_ARCHIVE):
 	curl -SL http://download.redis.io/releases/$(SOURCE_ARCHIVE) -o rpmbuild/SOURCES/$(SOURCE_ARCHIVE)
@@ -30,3 +31,4 @@ clean:
 	docker images | grep -q $(IMAGE_NAME)-centos7 && docker rmi $(IMAGE_NAME)-centos7 || true
 	docker images | grep -q $(IMAGE_NAME)-centos8 && docker rmi $(IMAGE_NAME)-centos8 || true
 	docker images | grep -q $(IMAGE_NAME)-almalinux8 && docker rmi $(IMAGE_NAME)-almalinux8 || true
+	docker images | grep -q $(IMAGE_NAME)-rockylinux8 && docker rmi $(IMAGE_NAME)-rockylinux8 || true


### PR DESCRIPTION
The status of Rocky Linux is still RC1
https://rockylinux.org/ja/news/rocky-linux-8-4-rc1-release/

However, it looks that the docker image is available on DockerHub.
https://wiki.rockylinux.org/en/link-directory
https://hub.docker.com/r/rockylinux/rockylinux